### PR TITLE
fix(rust): wasm-pack arguments + fix libs/apps relative paths

### DIFF
--- a/packages/rust/src/executors/wasm-pack/executor.ts
+++ b/packages/rust/src/executors/wasm-pack/executor.ts
@@ -1,5 +1,5 @@
 import { ExecutorContext } from '@nx/devkit';
-import { buildCommand } from '../../utils/build-command';
+import { buildCommand, buildWasmPackCommand } from '../../utils/build-command';
 import { runProcess } from '../../utils/run-process';
 import { WasmPackExecutorSchema } from './schema';
 
@@ -12,7 +12,7 @@ export default async function runExecutor(
   context: ExecutorContext
 ) {
   const wasmPackOptions = wasmPackArgs(options);
-  const args = buildCommand('build', wasmPackOptions, context);
+  const args = buildWasmPackCommand('build', wasmPackOptions, context);
   return runWasmPack(...args);
 }
 

--- a/packages/rust/src/utils/build-command.ts
+++ b/packages/rust/src/utils/build-command.ts
@@ -1,10 +1,9 @@
 import { ExecutorContext } from '@nx/devkit';
 import { BaseOptions } from '../models/base-options';
 
-export function buildCommand(
+function prebuildCommand(
   baseCommand: string,
   options: BaseOptions,
-  context: ExecutorContext
 ): string[] {
   const args = [];
 
@@ -32,8 +31,29 @@ export function buildCommand(
       args.push(`--${key}`, value);
     }
   }
+  return args;
+}
 
-  args.push('-p', context.projectName);
+function getProjectPath(context: ExecutorContext) {
+  return context.projectsConfigurations!/*is here 16+*/.projects[context.projectName!/*has to be here for it all to work*/].root;
+}
 
+export function buildCommand(
+  baseCommand: string,
+  options: BaseOptions,
+  context: ExecutorContext
+): string[] {
+  const args = prebuildCommand(baseCommand, options);
+  args.push('-p', getProjectPath(context));
+  return args;
+}
+
+export function buildWasmPackCommand(
+  baseCommand: string,
+  options: BaseOptions,
+  context: ExecutorContext
+): string[] {
+  const args = prebuildCommand(baseCommand, options);
+  args.push(getProjectPath(context));
   return args;
 }


### PR DESCRIPTION
This PR solves two issues that are interconnected in code

- wasm-pack doesn't recognize `-p` property and expects passing the project root without `-p`

- the plugin code doesn't respect libs/apps folders and only uses the app name, not prefixing it, therefore it doesn't recognize if i.e. my libs dir = packages/, and my app is `my-lib`, it'll search in `./my-lib` instead of `./packages/my-lib`