### PR TITLE
Add option to change package name

### DIFF
--- a/packages/rust/src/models/base-options.d.ts
+++ b/packages/rust/src/models/base-options.d.ts
@@ -1,4 +1,5 @@
 export interface BaseOptions {
+  package?: string;
   toolchain?: 'stable' | 'beta' | 'nightly';
   target?: string;
   profile?: string;

--- a/packages/rust/src/utils/build-command.ts
+++ b/packages/rust/src/utils/build-command.ts
@@ -33,7 +33,7 @@ export function buildCommand(
     }
   }
 
-  if (!args.includes("--package") && !args.includes("-p")) {
+  if (!args.includes("--package")) {
     args.push("-p", context.projectName);
   }
 

--- a/packages/rust/src/utils/build-command.ts
+++ b/packages/rust/src/utils/build-command.ts
@@ -33,7 +33,9 @@ export function buildCommand(
     }
   }
 
-  args.push('-p', context.projectName);
+  if (!args.includes("--package") && !args.includes("-p")) {
+    args.push("-p", context.projectName);
+  }
 
   return args;
 }


### PR DESCRIPTION
This allows you to use a different Rust package name than the Nx project name.

```
{
  "name": "foobar",
  "projectType": "application",
  "targets": {
    "build": {
      "executor": "@monodon/rust:build",
      "options": {
        "package": "barfoo"
      },
```