### PR TITLE
fix(rust): git dependencies are external

### DIFF
--- a/packages/rust/src/utils/cargo.ts
+++ b/packages/rust/src/utils/cargo.ts
@@ -100,5 +100,9 @@ export function cargoMetadata(): CargoMetadata | null {
 }
 
 export function isExternal(packageOrDep: Package | Dependency) {
-  return packageOrDep.source?.startsWith('registry+') ?? false;
+  return (
+    (packageOrDep.source?.startsWith('registry+') ||
+      packageOrDep.source?.startsWith('git+')) ??
+    false
+  );
 }


### PR DESCRIPTION
Currently, if we try to add a git Cargo dependency, the plugin will fail to process the project graph, because it is not recognized as an external dependency. This PR fixes that.

Fixes #40