### PR TITLE
fix(rust): Consider git and outside local source as external when building the graph

### DIFF
--- a/packages/rust/src/graph.ts
+++ b/packages/rust/src/graph.ts
@@ -35,8 +35,10 @@ export const createNodes: CreateNodes = [
     }, new Map<string, Package>());
 
     for (const pkg of cargoPackages) {
-      if (!isExternal(pkg)) {
-        const root = normalizePath(dirname(relative(ctx.workspaceRoot, pkg.manifest_path)));
+      if (!isExternal(pkg, ctx.workspaceRoot)) {
+        const root = normalizePath(
+          dirname(relative(ctx.workspaceRoot, pkg.manifest_path))
+        );
         projects[root] = {
           root,
           name: pkg.name,
@@ -45,7 +47,7 @@ export const createNodes: CreateNodes = [
         };
       }
       for (const dep of pkg.dependencies) {
-        if (isExternal(dep)) {
+        if (isExternal(dep, ctx.workspaceRoot)) {
           const externalDepName = `cargo:${dep.name}`;
           if (!externalNodes?.[externalDepName]) {
             externalNodes[externalDepName] = {


### PR DESCRIPTION
## Problem

When working with dependencies referenced from git and local sources outside the workspace, nx throws an error saying the dependency is outside the workspace.

Ex: 

```
[dependencies]
poem = { git = "https://github.com/poem-web/poem.git", branch = "fix/som-bug-fix" }

or 

poem = { git = "../../../../poem", branch = "fix/som-bug-fix" }
```

## Fix

Check is the dependency is Git or a local path outside the workspace before adding to the graph.

fixes https://github.com/Cammisuli/monodon/issues/40