### PR TITLE
fix(rust): make project node dep packageRoot resolvable

### DIFF
--- a/packages/rust/src/generators/release-version/release-version.spec.ts
+++ b/packages/rust/src/generators/release-version/release-version.spec.ts
@@ -146,7 +146,7 @@ describe('release-version', () => {
       });
 
       expect(outputSpy).toHaveBeenCalledWith({
-        title: `The project "my-lib" does not have a Cargo.toml available at libs/my-lib/Cargo.toml.
+        title: `The project "my-lib" does not have a Cargo.toml available at packages/rust/libs/my-lib/Cargo.toml.
 
 To fix this you will either need to add a Cargo.toml file at that location, or configure "release" within your nx.json to exclude "my-lib" from the current release group, or amend the packageRoot configuration to point to where the Cargo.toml should be.`,
       });

--- a/packages/rust/src/generators/release-version/release-version.spec.ts
+++ b/packages/rust/src/generators/release-version/release-version.spec.ts
@@ -146,7 +146,7 @@ describe('release-version', () => {
       });
 
       expect(outputSpy).toHaveBeenCalledWith({
-        title: `The project "my-lib" does not have a Cargo.toml available at packages/rust/libs/my-lib/Cargo.toml.
+        title: `The project "my-lib" does not have a Cargo.toml available at libs/my-lib/Cargo.toml.
 
 To fix this you will either need to add a Cargo.toml file at that location, or configure "release" within your nx.json to exclude "my-lib" from the current release group, or amend the packageRoot configuration to point to where the Cargo.toml should be.`,
       });

--- a/packages/rust/src/generators/release-version/release-version.ts
+++ b/packages/rust/src/generators/release-version/release-version.ts
@@ -564,7 +564,7 @@ interface LocalPackageDependency extends ProjectGraphDependency {
   dependencyCollection: 'dependencies' | 'dev-dependencies';
 }
 
-function updateProjectNameToPackageRootMap(
+function fillPackageRootMap(
   projectNameToPackageRootMap: Map<string, string>,
   projectNode: ProjectGraphProjectNode,
   resolvePackageRoot: (projectNode: ProjectGraphProjectNode) => string
@@ -575,7 +575,9 @@ function updateProjectNameToPackageRootMap(
   if (!packageRoot) {
     const resolvedPackageRoot = resolvePackageRoot(projectNode);
     // Append it to the map for later use within the release version generator
-    projectNameToPackageRootMap.set(projectNode.name, resolvedPackageRoot);
+    if (resolvedPackageRoot) {
+      projectNameToPackageRootMap.set(projectNode.name, resolvedPackageRoot);
+    }
   }
 }
 
@@ -596,7 +598,7 @@ function resolveLocalPackageDependencies(
   for (const projectNode of projects) {
     // Ensure that the packageRoot is resolved for the project and added to the map for later use
     if (includeAll) {
-      updateProjectNameToPackageRootMap(
+      fillPackageRootMap(
         projectNameToPackageRootMap,
         projectNode,
         resolvePackageRoot
@@ -613,7 +615,7 @@ function resolveLocalPackageDependencies(
         continue;
       }
       // Ensure that the packageRoot is resolved for the dependent project and added to the map for later use
-      updateProjectNameToPackageRootMap(
+      fillPackageRootMap(
         projectNameToPackageRootMap,
         depProject,
         resolvePackageRoot


### PR DESCRIPTION
While trying to integrate nx release with my rust & js monorepo i was having 2 issues regarding the version not being found and the packageRoot, also, my project uses groups, unsure if the errors could also be caused by that.

The first was that since i was doing the first release and some projects would not have the version available that strict .match was being done in an `undefined` value which resolved in an error. 

The second was that nx dependency graph apparently includes everything in the monorepo, and when i have dependencies of my dependencies those were not being added to the `projectNameToPackageRootMap` which resulted in the project packageRoot not being found.

I made a quick attempt at fixing both with this PR, let me me know if the changes are reasonable, thanks.