### PR TITLE
fix: remove relative path format

### DIFF
--- a/packages/rust/src/generators/binary/generator.spec.ts
+++ b/packages/rust/src/generators/binary/generator.spec.ts
@@ -61,7 +61,7 @@ describe('rust generator', () => {
         },
         "workspace": Object {
           "members": Array [
-            "./test_name",
+            "test_name",
           ],
           "resolver": "2",
         },

--- a/packages/rust/src/generators/library/generator.spec.ts
+++ b/packages/rust/src/generators/library/generator.spec.ts
@@ -61,7 +61,7 @@ describe('rust generator', () => {
         },
         "workspace": Object {
           "members": Array [
-            "./test_name",
+            "test_name",
           ],
           "resolver": "2",
         },

--- a/packages/rust/src/utils/add-to-workspace.ts
+++ b/packages/rust/src/utils/add-to-workspace.ts
@@ -18,10 +18,13 @@ export function addToCargoWorkspace(tree: Tree, projectPath: string) {
     throw new Error('Cargo.toml workspace section does not contain members');
   }
 
-  if (members.includes(projectPath)) {
-    logger.info(`${projectPath} already exists in the Cargo.toml members`);
+  // Remove leading './' if it exists
+  const cleanProjectPath = projectPath.replace(/^\.\//, '');
+
+  if (members.includes(cleanProjectPath)) {
+    logger.info(`${cleanProjectPath} already exists in the Cargo.toml members`);
   } else {
-    workspace.members = members.concat([projectPath]);
+    workspace.members = members.concat([cleanProjectPath]);
   }
 
   const newCargoToml = stringifyCargoToml(cargoToml);


### PR DESCRIPTION
It removes the leading `./` from crate path since `member` array does not require