### PR TITLE
Fix dangling process when terminating a long running process with SIG…

### DIFF
--- a/packages/rust/src/utils/cargo.ts
+++ b/packages/rust/src/utils/cargo.ts
@@ -32,7 +32,7 @@ export function cargoRunCommand(
     childProcess = spawn('cargo', [...args, '--color', 'always'], {
       cwd: process.cwd(),
       windowsHide: true,
-      detached: true,
+      detached: false,
       shell: false,
       stdio: ['inherit', 'inherit', 'inherit'],
     });


### PR DESCRIPTION
## Issue

For long running processes like a web server, the plugin sometimes fails to terminate the running child-process.

## Fix: `detached: false`

As the stdio is inherited, the running console is attached anyway, and `detached: false` should have no impact other than explicitly binding the lifetime of the child-process to it's parent. https://nodejs.org/api/child_process.html#optionsdetached