### PR TITLE
fix(release-version): handle project without cargo.toml and include dependents in dependent mode

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.79.0"
+channel = "1.80.0"
 targets = ["wasm32-wasip1-threads"]
 profile = "default"


### PR DESCRIPTION
I made these changes to allow the closure of the https://github.com/Cammisuli/monodon/issues/62.

- filter projects to use only dependents of filtered projects in case of 'dependent' relationship project
- add test to project that don't have` cargo.toml `file