### PR TITLE
feat(rust): add `CreateNodesV2` implementation to the graph plugin

### DIFF
--- a/packages/rust/src/graph.ts
+++ b/packages/rust/src/graph.ts
@@ -1,92 +1,146 @@
 import {
-  CreateDependencies,
-  CreateNodes,
-  ProjectConfiguration,
-  RawProjectGraphDependency,
+  createNodesFromFiles,
   normalizePath,
   workspaceRoot,
+  type CreateDependencies,
+  type CreateNodes,
+  type CreateNodesContext,
+  type CreateNodesContextV2,
+  type CreateNodesV2,
+  type ProjectConfiguration,
+  type RawProjectGraphDependency,
 } from '@nx/devkit';
 import {
   DependencyType,
   ProjectGraphExternalNode,
 } from 'nx/src/config/project-graph';
 import { dirname, relative } from 'path';
-import { Package } from './models/cargo-metadata';
+import type { Package } from './models/cargo-metadata';
 import { cargoMetadata, isExternal } from './utils/cargo';
 
-export const createNodes: CreateNodes = [
-  '*/**/Cargo.toml',
-  (projectFile, opts, ctx) => {
-    const metadata = cargoMetadata();
-    if (!metadata) {
-      return {};
-    }
+const cargoGlob = '*/**/Cargo.toml';
 
-    const { packages: cargoPackages } = metadata;
+export const createNodesV2: CreateNodesV2 = [
+  cargoGlob,
+  async (configFilePaths, options, context) => {
+    const result = processCargoMetadata(context);
 
-    const externalNodes: Record<string, ProjectGraphExternalNode> = {};
-    const projects: Record<string, ProjectConfiguration> = {};
-
-    const cargoPackageMap = cargoPackages.reduce((acc, p) => {
-      if (!acc.has(p.name)) {
-        acc.set(p.name, p);
-      }
-      return acc;
-    }, new Map<string, Package>());
-
-    for (const pkg of cargoPackages) {
-      if (!isExternal(pkg, ctx.workspaceRoot)) {
-        const root = normalizePath(
-          dirname(relative(ctx.workspaceRoot, pkg.manifest_path))
-        );
-
-        // TODO(cammisuli): provide defaults for non-project.json workspaces
-        const targets: ProjectConfiguration['targets'] = {};
-
-        // Apply nx-release-publish target for non-private projects
-        const isPrivate = pkg.publish?.length === 0;
-        if (!isPrivate) {
-          targets['nx-release-publish'] = {
-            dependsOn: ['^nx-release-publish'],
-            executor: '@monodon/rust:release-publish',
-            options: {},
-          };
+    return await createNodesFromFiles(
+      async (configFile, options, context) => {
+        const projects = filterProject(result.projects, configFile);
+        if (!projects) {
+          return { projects: {}, externalNodes: {} };
         }
 
-        projects[root] = {
-          root,
-          name: pkg.name,
-          targets,
-          release: {
-            version: {
-              generator: '@monodon/rust:release-version',
-            },
-          },
-        };
-      }
-      for (const dep of pkg.dependencies) {
-        if (isExternal(dep, ctx.workspaceRoot)) {
-          const externalDepName = `cargo:${dep.name}`;
-          if (!externalNodes?.[externalDepName]) {
-            externalNodes[externalDepName] = {
-              type: 'cargo' as any,
-              name: externalDepName as any,
-              data: {
-                packageName: dep.name,
-                version: cargoPackageMap.get(dep.name)?.version ?? '0.0.0',
-              },
-            };
-          }
-        }
-      }
-    }
-
-    return {
-      projects,
-      externalNodes,
-    };
+        return { projects, externalNodes: result.externalNodes };
+      },
+      configFilePaths,
+      options,
+      context
+    );
   },
 ];
+
+export const createNodes: CreateNodes = [
+  cargoGlob,
+  (projectFile, opts, context) => {
+    const result = processCargoMetadata(context);
+
+    const projects = filterProject(result.projects, projectFile);
+    if (!projects) {
+      return { projects: {}, externalNodes: {} };
+    }
+
+    return { projects, externalNodes: result.externalNodes };
+  },
+];
+
+function processCargoMetadata(ctx: CreateNodesContext | CreateNodesContextV2): {
+  projects: Record<string, ProjectConfiguration>;
+  externalNodes: Record<string, ProjectGraphExternalNode>;
+} {
+  const metadata = cargoMetadata();
+  if (!metadata) {
+    return { projects: {}, externalNodes: {} };
+  }
+
+  const { packages: cargoPackages } = metadata;
+
+  const externalNodes: Record<string, ProjectGraphExternalNode> = {};
+  const projects: Record<string, ProjectConfiguration> = {};
+
+  const cargoPackageMap = cargoPackages.reduce((acc, p) => {
+    if (!acc.has(p.name)) {
+      acc.set(p.name, p);
+    }
+    return acc;
+  }, new Map<string, Package>());
+
+  for (const pkg of cargoPackages) {
+    if (!isExternal(pkg, ctx.workspaceRoot)) {
+      const root = normalizePath(
+        dirname(relative(ctx.workspaceRoot, pkg.manifest_path))
+      );
+
+      // TODO(cammisuli): provide defaults for non-project.json workspaces
+      const targets: ProjectConfiguration['targets'] = {};
+
+      // Apply nx-release-publish target for non-private projects
+      const isPrivate = pkg.publish?.length === 0;
+      if (!isPrivate) {
+        targets['nx-release-publish'] = {
+          dependsOn: ['^nx-release-publish'],
+          executor: '@monodon/rust:release-publish',
+          options: {},
+        };
+      }
+
+      projects[root] = {
+        root,
+        name: pkg.name,
+        targets,
+        release: {
+          version: {
+            generator: '@monodon/rust:release-version',
+          },
+        },
+      };
+    }
+    for (const dep of pkg.dependencies) {
+      if (isExternal(dep, ctx.workspaceRoot)) {
+        const externalDepName = `cargo:${dep.name}`;
+        if (!externalNodes?.[externalDepName]) {
+          externalNodes[externalDepName] = {
+            type: 'cargo' as any,
+            name: externalDepName as any,
+            data: {
+              packageName: dep.name,
+              version: cargoPackageMap.get(dep.name)?.version ?? '0.0.0',
+            },
+          };
+        }
+      }
+    }
+  }
+
+  return {
+    projects,
+    externalNodes,
+  };
+}
+
+function filterProject(
+  projects: Record<string, ProjectConfiguration>,
+  configFile: string
+): Record<string, ProjectConfiguration> | null {
+  const configDir = normalizePath(dirname(configFile));
+
+  if (projects[configDir]) {
+    return { [configDir]: projects[configDir] };
+  }
+
+  return null;
+}
 
 export const createDependencies: CreateDependencies = (
   _,

--- a/packages/rust/src/index.ts
+++ b/packages/rust/src/index.ts
@@ -1,10 +1,11 @@
 import { NxPlugin } from '@nx/devkit';
-import { createDependencies, createNodes } from './graph';
+import { createDependencies, createNodes, createNodesV2 } from './graph';
 
 const nxPlugin: NxPlugin = {
   name: '@monodon/rust',
   createDependencies,
   createNodes,
+  createNodesV2,
 };
 
 export = nxPlugin;


### PR DESCRIPTION
Add the `CreateNodesV2` API implementation to the Rust graph plugin. With this, the `cargo metadata` command will run once per plugin invocation and results will be returned correctly scoped to the particular configuration file being processed.