### PR TITLE
fix(rust): inherit RUSTC_WRAPPER in runProcess instead of forcing empty string

### DIFF
--- a/packages/rust/src/utils/run-process.ts
+++ b/packages/rust/src/utils/run-process.ts
@@ -21,7 +21,6 @@ export function runProcess(
       cwd: process.cwd(),
       env: {
         ...process.env,
-        RUSTC_WRAPPER: '',
         CARGO_TARGET_DIR: targetDir,
         CARGO_BUILD_TARGET_DIR: targetDir,
       },


### PR DESCRIPTION
### Summary

`runProcess` was passing `RUSTC_WRAPPER: ''` into `execSync`, which overrides any value from `process.env` and disables legitimate compiler wrappers (**sccache**, custom `rustc` shims, etc.) for every Cargo invocation started through the Nx plugin.

### Change

Remove the `RUSTC_WRAPPER` override so spawned processes inherit the parent environment.

### Context

Found by **Nate Bomberger** while integrating **Nx + Rust + sccache** at [Smash](https://smsh.run) / **najabu** — wrapper was effectively stripped on every Monodon-driven build. The same one-line fix is validated in our monorepo via `pnpm patch` against `@monodon/rust`.

### Test plan

- [ ] With `RUSTC_WRAPPER=sccache` in the environment, run a Monodon-backed `nx` Rust target and confirm the wrapper is used (e.g. sccache statistics).
- [ ] Workspace `nx run-many` / CI still passes for this repo.

### Note

If this line existed for a historical edge case, an alternative would be an opt-in env var to clear the wrapper; the default should preserve `RUSTC_WRAPPER` for users who set it intentionally.
